### PR TITLE
Local dev: allow http OIDC authority + local compose

### DIFF
--- a/ODPC.Server/Authentication/AuthenticationExtensions.cs
+++ b/ODPC.Server/Authentication/AuthenticationExtensions.cs
@@ -81,6 +81,10 @@ namespace ODPC.Authentication
                     options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
 
                     options.Authority = authOptions.Authority;
+                    // Local/dev only: allow an http OIDC authority (e.g. a local Keycloak).
+                    // Defaults to requiring HTTPS; set OIDC_REQUIRE_HTTPS=false to relax.
+                    options.RequireHttpsMetadata =
+                        Environment.GetEnvironmentVariable("OIDC_REQUIRE_HTTPS") != "false";
                     options.ClientId = authOptions.ClientId;
                     options.ClientSecret = authOptions.ClientSecret;
                     options.SignedOutRedirectUri = SignOutCallback;

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,11 @@
+# Local-only: the odpc app requires OIDC_* config that the demo compose does not
+# ship (it expects a real OpenID Connect IdP via user-secrets / Azure AD).
+# Placeholder values let the server boot and serve the SPA; actual login needs
+# a real IdP (point these at e.g. Keycloak/Entra to enable sign-in).
+services:
+  odpc:
+    environment:
+      - OIDC_AUTHORITY=http://localhost:8888/realms/dev
+      - OIDC_CLIENT_ID=odpc-local
+      - OIDC_CLIENT_SECRET=local-placeholder-secret
+      - OIDC_ADMIN_ROLE=odpc-admin


### PR DESCRIPTION
## What

Adds local-development support so the ODPC server can boot and be exercised outside a fully-provisioned OIDC environment.

- **`ODPC.Server/Authentication/AuthenticationExtensions.cs`** — new `OIDC_REQUIRE_HTTPS` env toggle. Defaults to requiring HTTPS metadata (unchanged production behaviour); set `OIDC_REQUIRE_HTTPS=false` to allow an `http://` OIDC authority.
- **`docker-compose.local.yml`** (new) — placeholder `OIDC_*` values so the server starts and serves the SPA.

## Why

The demo compose expects a real OpenID Connect IdP (via user-secrets / Azure AD), so the server would not boot locally. During the integrated-stack / E2E work we run against a local Keycloak on plain `http://`, which the OIDC middleware rejects by default (`RequireHttpsMetadata=true`). The env toggle lets local/CI point at a local Keycloak without weakening the production default; the compose override supplies bootable placeholder config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)